### PR TITLE
Site querying at module level

### DIFF
--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -23,6 +23,8 @@ STATUS_CHOICES = (
 
 sites_field = None
 if USE_SITES:
+    from django.contrib.sites.models import Site
+
     def default_site():
         return Site.objects.get_current_site()
 


### PR DESCRIPTION
Stephen,

I moved the Site query into a callable and set the default based on that rather than doing the query at module level, we were still getting errors with syncdb/test/etc.

Thanks,

Chris
