### PR TITLE
make length of AbstractField.choices configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ The following settings can be defined in your project's ``settings`` module.
 
   * ``FORMS_BUILDER_FIELD_MAX_LENGTH`` - Maximum allowed length for field values. Defaults to ``2000``
   * ``FORMS_BUILDER_LABEL_MAX_LENGTH`` - Maximum allowed length for field labels. Defaults to ``20``
+  * ``FORMS_BUILDER_CHOICES_MAX_LENGTH`` - Maximum allowed length for field choices. Defaults to ``FORMS_BUILDER_FIELD_MAX_LENGTH``
   * ``FORMS_BUILDER_UPLOAD_ROOT`` - The absolute path where files will be uploaded to. Defaults to ``None``
   * ``FORMS_BUILDER_USE_HTML5`` - Boolean controlling whether HTML5 form fields are used. Defaults to ``True``
   * ``FORMS_BUILDER_USE_SITES`` - Boolean controlling whether forms are associated to Django's Sites framework. Defaults to ``"django.contrib.sites" in settings.INSTALLED_APPS``

--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -152,7 +152,7 @@ class AbstractField(models.Model):
     field_type = models.IntegerField(_("Type"), choices=fields.NAMES)
     required = models.BooleanField(_("Required"), default=True)
     visible = models.BooleanField(_("Visible"), default=True)
-    choices = models.CharField(_("Choices"), max_length=settings.FIELD_MAX_LENGTH, blank=True,
+    choices = models.CharField(_("Choices"), max_length=settings.CHOICES_MAX_LENGTH, blank=True,
         help_text="Comma separated options where applicable. If an option "
             "itself contains commas, surround the option starting with the %s"
             "character and ending with the %s character." %

--- a/forms_builder/forms/settings.py
+++ b/forms_builder/forms/settings.py
@@ -8,6 +8,9 @@ FIELD_MAX_LENGTH = getattr(settings, "FORMS_BUILDER_FIELD_MAX_LENGTH", 2000)
 # The maximum allowed length for field labels.
 LABEL_MAX_LENGTH = getattr(settings, "FORMS_BUILDER_LABEL_MAX_LENGTH", 200)
 
+# The maximum allowed length for field choices.
+CHOICES_MAX_LENGTH = getattr(settings, 'FORMS_BUILDER_CHOICES_MAX_LENGTH', FIELD_MAX_LENGTH)
+
 # The absolute path where files will be uploaded to.
 UPLOAD_ROOT = getattr(settings, "FORMS_BUILDER_UPLOAD_ROOT", None)
 


### PR DESCRIPTION
The length of the _choices_ field in _AbstractField_ should be configurable and not static, just like the _default_ field. I am proposing to use the FIELD_MAX_LENGTH option.
