### PR TITLE
fix: csv export appends to result on each iteration

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -98,9 +98,9 @@ class FormAdmin(admin.ModelAdmin):
                 csv.writerow(entries_form.columns())
                 for row in entries_form.rows(csv=True):
                     csv.writerow(row)
-                    # Decode and reencode the response into utf-16 to be Excel compatible
-                    data = queue.getvalue().decode("utf-8").encode("utf-16")
-                    response.write(data)
+                # Decode and reencode entire queued response into utf-16 to be Excel compatible
+                data = queue.getvalue().decode("utf-8").encode("utf-16")
+                response.write(data)
                 return response
             elif request.POST.get("delete") and can_delete_entries:
                 selected = request.POST.getlist("selected")


### PR DESCRIPTION
Steps to reproduce:
- create new form
- add single-text field
- submit form more than once

When exporting entries as CSV, the resulting file will contain column headers as well as entries multiple times.

This is caused by `response.write()`being inside the for-loop, so that an interim result is appended to the reponse in each iteration. Looks like this part simply has wrong indentation.

I couldn't test the Excel compatibility that the code was originally introduced for but it shouldn't be affected by this patch.
