### PR TITLE
Avoid KeyError 'request' not found error when an anonymous user is viewi...

### DIFF
--- a/forms_builder/forms/templatetags/forms_builder_tags.py
+++ b/forms_builder/forms/templatetags/forms_builder_tags.py
@@ -1,4 +1,3 @@
-
 from django import template
 from django.template.loader import get_template
 
@@ -16,7 +15,7 @@ class BuiltFormNode(template.Node):
         self.value = value
 
     def render(self, context):
-        user = context["request"].user
+        user = context.get("user", None)
         if self.name != "form":
             lookup = {
                 str(self.name): template.Variable(self.value).resolve(context)


### PR DESCRIPTION
Avoid KeyError 'request' not found error when an anonymous user is viewing the form.
