### PR TITLE
Field slug editable, but excluded in admin form.

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -36,6 +36,7 @@ if USE_SITES:
 
 class FieldAdmin(admin.TabularInline):
     model = Field
+    exclude = ('slug', )
 
 class FormAdmin(admin.ModelAdmin):
 

--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -155,7 +155,7 @@ class AbstractField(models.Model):
 
     label = models.CharField(_("Label"), max_length=settings.LABEL_MAX_LENGTH)
     slug = models.SlugField(_('Slug'), max_length=100, blank=True,
-            editable=False, default="")
+            default="")
     field_type = models.IntegerField(_("Type"), choices=fields.NAMES)
     required = models.BooleanField(_("Required"), default=True)
     visible = models.BooleanField(_("Visible"), default=True)


### PR DESCRIPTION
Standard behavior stays same as discussed in #63 but
allows one to customize if field slugs are visible/editable in
administration interface.
