### PR TITLE
View results templatetag

### DIFF
--- a/forms_builder/forms/templatetags/forms_builder_tags.py
+++ b/forms_builder/forms/templatetags/forms_builder_tags.py
@@ -64,25 +64,27 @@ def render_built_form(parser, token):
     return BuiltFormNode(name, value)
 
 
-@register.assignment_tag(takes_context=True)
-def form_results(context, form_id, sort_by_cols=None):
-    """
-    form_results requires the form instance id:
+# assignment_tag works only for Django 1.4
+if hasattr(register, 'assignment_tag'):
+    @register.assignment_tag(takes_context=True)
+    def form_results(context, form_id, sort_by_cols=None):
+        """
+        form_results requires the form instance id:
 
-    {% form_results form_instance.id as mytag %}
+        {% form_results form_instance.id as mytag %}
 
-    results may be sorted by given column number(s):
+        results may be sorted by given column number(s):
 
-    {% form_results form_instance.id sort_by_cols="0" as mytag %}
-    {% form_results form_instance.id sort_by_cols="3,1" as mytag %}
+        {% form_results form_instance.id sort_by_cols="0" as mytag %}
+        {% form_results form_instance.id sort_by_cols="3,1" as mytag %}
 
-    """
-    request = context['request']
-    published = Form.objects.published(for_user=request.user)
-    form = get_object_or_404(published, pk=form_id)
-    rows = EntriesForm(form, request, None).rows()
-    if sort_by_cols:
-        cols = [int(c) for c in sort_by_cols.split(',')]
-        rows = sorted(rows,
-            key=lambda x: ''.join(operator.itemgetter(*cols)(x)).lower())
-    return rows
+        """
+        request = context['request']
+        published = Form.objects.published(for_user=request.user)
+        form = get_object_or_404(published, pk=form_id)
+        rows = EntriesForm(form, request, None).rows()
+        if sort_by_cols:
+            cols = [int(c) for c in sort_by_cols.split(',')]
+            rows = sorted(rows,
+                key=lambda x: ''.join(operator.itemgetter(*cols)(x)).lower())
+        return rows


### PR DESCRIPTION
Don't know if actually needed by anyone else, anyway: Adding a template tag to easily display results of an existing form for Django >=1.4.

Usage in template:

```
{% load forms_builder_tags %}

<h4>List of Participants</h4>
<ul>
{% form_results form_id=1 sort_by_cols="1,2" as results %}
{% for entry in results %}
  <li>{{entry.1}}, {{entry.2}}</li>
{% endfor %}
</ul>
```
