### PR TITLE
Clean checkbox initial values

### DIFF
--- a/forms_builder/forms/forms.py
+++ b/forms_builder/forms/forms.py
@@ -124,6 +124,9 @@ class FormForForm(forms.ModelForm):
             else:
                 if field.is_a(*fields.MULTIPLE):
                     initial_val = [x.strip() for x in initial_val.split(",")]
+                if field.field_type == fields.CHECKBOX:
+                    # Clean boolean value
+                    initial_val = (initial_val == 'True')
                 self.initial[field_key] = initial_val
             self.fields[field_key] = field_class(**field_args)
 


### PR DESCRIPTION
Convert initial values for checkboxes into boolean from unicode. Otherwise, when initial value is `u'False'`, the checkbox renders with `checked="checked"`.
