### PR TITLE
Don't send email from form submitter's email address.

### DIFF
--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -53,11 +53,12 @@ def form_detail(request, slug, template="forms/form_detail.html"):
                 send_mail_template(subject, "form_response", email_from,
                                    email_to, context=context,
                                    fail_silently=settings.DEBUG)
+            headers = None
+            if email_to:
+                # Add the email entered as a Reply-To header
+                headers = {'Reply-To': email_to}
             email_copies = split_choices(form.email_copies)
             if email_copies:
-                if email_to and SEND_FROM_SUBMITTER:
-                    # Send from the email entered.
-                    email_from = email_to
                 attachments = []
                 for f in form_for_form.files.values():
                     f.seek(0)
@@ -65,7 +66,8 @@ def form_detail(request, slug, template="forms/form_detail.html"):
                 send_mail_template(subject, "form_response", email_from,
                                    email_copies, context=context,
                                    attachments=attachments,
-                                   fail_silently=settings.DEBUG)
+                                   fail_silently=settings.DEBUG,
+                                   headers=headers)
             form_valid.send(sender=request, form=form_for_form, entry=entry)
             return redirect(reverse("form_sent", kwargs={"slug": form.slug}))
     context = {"form": form}


### PR DESCRIPTION
Changed form_detail view to send mail from the form specified from address or the DEFAULT_FROM_EMAIL instead of the form submitter's own
email address. User submitted email address is instead now specified
in a Reply-To header. Closes #108. Please note that optional headers had to be added to send_mail_template in django-email-extras (https://github.com/stephenmcd/django-email-extras/pull/8) for this to work.
