### PR TITLE
Extra widgets

### DIFF
--- a/forms_builder/forms/settings.py
+++ b/forms_builder/forms/settings.py
@@ -12,6 +12,10 @@ LABEL_MAX_LENGTH = getattr(settings, "FORMS_BUILDER_LABEL_MAX_LENGTH", 200)
 # Sequence of custom fields that will be added to the form field types.
 EXTRA_FIELDS = getattr(settings, "FORMS_BUILDER_EXTRA_FIELDS", ())
 
+# Sequence of custom widgets that will be added to the form fields widgets
+# or replace existing.
+EXTRA_WIDGETS = getattr(settings, "FORMS_BUILDER_EXTRA_WIDGETS", ())
+
 # The absolute path where files will be uploaded to.
 UPLOAD_ROOT = getattr(settings, "FORMS_BUILDER_UPLOAD_ROOT", None)
 


### PR DESCRIPTION
Hi Stephen, I think would be good if you can set extra widgets for extra or default fields.
for example:

FORMS_BUILDER_EXTRA_FIELDS = (
    (100, 'my_module.fields.MyCustomField', 'My field'),
    (101, 'my_module.fields.MyCustomField', 'My field', 'my_module.widgets.MyCustomWidget'),
    (102, 'my_module.fields.MyCustomField', 'My field', ('email', 'django.forms.widgets.TextInput')),  # html5
    (103, 'my_module.fields.MyCustomField', 'My field'),
)

FORMS_BUILDER_EXTRA_WIDGETS = (
    (103, ('date', 'django.forms.widgets.DateInput')),
    (10, 'django.forms.widgets.DateInput'), 
)
