### PR TITLE
Use self.formentry_model in FormAdmin.entries_view instead of FormEntry directly

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -170,7 +170,7 @@ class FormAdmin(admin.ModelAdmin):
                     except ImportError:
                         def info(request, message, fail_silently=True):
                             request.user.message_set.create(message=message)
-                    entries = FormEntry.objects.filter(id__in=selected)
+                    entries = self.formentry_model.objects.filter(id__in=selected)
                     count = entries.count()
                     if count > 0:
                         entries.delete()


### PR DESCRIPTION
This small change allows a developer to use your FormAdmin to create a customized one, by inheriting it.

Something like this:

```
class FieldAdmin(admin.TabularInline):
    model = CustomField
    exclude = ('slug', )

class CustomFormAdmin(FormAdmin):
    formentry_model = CustomFormEntry
    fieldentry_model = CustomFieldEntry
    inlines = (FieldAdmin,)
    fieldsets = form_admin_fieldsets


admin.site.unregister(Form)
```

This `unregister` at the end seems necessary, even the `forms_builder.forms` isn't added in `INSTALLED_APPS`. Without it, the entries views urls will point to the original app.

The purpose here is to create a new app for customizing your form models, but without rewriting most of the code. My custom models inherit from your abstract ones. Then, I inherited from `FormForForm` and changed its `Meta` to reference my `CustomFormEntry`.

I also created my own `FormDetail` view, but I believe it is possible to parametrize it to make it compatible with custom models.
