### PR TITLE
Moved form logic from view to mixin

### DIFF
--- a/forms_builder/forms/templates/forms/includes/built_form.html
+++ b/forms_builder/forms/templates/forms/includes/built_form.html
@@ -2,7 +2,7 @@
     {% if form.intro %}
     <p>{{ form.intro }}</p>
     {% endif %}
-    <form action="{% if action %}{{ action }}{% else %}{{ form.get_absolute_url }}{% endif %}" method="post"
+    <form action="{{ form.get_absolute_url }}" method="post"
         {% if form_for_form.is_multipart %}enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ form_for_form.as_p }}


### PR DESCRIPTION
Since I want to reuse the form logic in my Django CMS plugin, I refactored the view to implement the mixin class that can also be used in other views than the default FormDetail-TemplateView.
