### PR TITLE
add redirection ability for a successful form submission to show a customized confirmation page

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -37,6 +37,7 @@ form_admin_fieldsets = [
     (None, {"fields": ("title", ("status", "login_required",),
         ("publish_date", "expiry_date",),
         "intro", "button_text", "response")}),
+    (_('Redirection'), {'fields': ('redirect_url',), 'classes': ('collapse',)}),
     (_("Email"), {"fields": ("send_email", "email_from", "email_copies",
         "email_subject", "email_message")}),]
 

--- a/forms_builder/forms/migrations/0007_auto__add_field_form_redirect_url.py
+++ b/forms_builder/forms/migrations/0007_auto__add_field_form_redirect_url.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Form.redirect_url'
+        db.add_column('forms_form', 'redirect_url',
+                      self.gf('django.db.models.fields.CharField')(null=True, max_length=200, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Form.redirect_url'
+        db.delete_column('forms_form', 'redirect_url')
+
+
+    models = {
+        'forms.field': {
+            'Meta': {'object_name': 'Field', 'ordering': "('order',)"},
+            'choices': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'default': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'field_type': ('django.db.models.fields.IntegerField', [], {}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fields'", 'to': "orm['forms.Form']"}),
+            'help_text': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'placeholder_text': ('django.db.models.fields.CharField', [], {'null': 'True', 'max_length': '100', 'blank': 'True'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '100', 'default': "''", 'blank': 'True'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'forms.fieldentry': {
+            'Meta': {'object_name': 'FieldEntry'},
+            'entry': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fields'", 'to': "orm['forms.FormEntry']"}),
+            'field_id': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'null': 'True', 'max_length': '2000'})
+        },
+        'forms.form': {
+            'Meta': {'object_name': 'Form'},
+            'button_text': ('django.db.models.fields.CharField', [], {'max_length': '50', 'default': "'Submit'"}),
+            'email_copies': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'email_from': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'email_subject': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'expiry_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'intro': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'publish_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'redirect_url': ('django.db.models.fields.CharField', [], {'null': 'True', 'max_length': '200', 'blank': 'True'}),
+            'response': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'send_email': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'forms_form_forms'", 'symmetrical': 'False', 'default': '[1]', 'to': "orm['sites.Site']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'forms.formentry': {
+            'Meta': {'object_name': 'FormEntry'},
+            'entry_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entries'", 'to': "orm['forms.Form']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'sites.site': {
+            'Meta': {'db_table': "'django_site'", 'object_name': 'Site', 'ordering': "('domain',)"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['forms']

--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -1,13 +1,15 @@
 from __future__ import unicode_literals
-from future.builtins import str
 
-from django.core.urlresolvers import reverse
 from django.conf import settings as django_settings
 from django.contrib.sites.models import Site
+from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
+from django.core.validators import URLValidator, RegexValidator
 from django.db import models
 from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext, ugettext_lazy as _
+from future.builtins import str
 
 from forms_builder.forms import fields
 from forms_builder.forms import settings
@@ -21,6 +23,24 @@ STATUS_CHOICES = (
     (STATUS_PUBLISHED, _("Published")),
 )
 
+class RedirectUrlValidator(object):
+    message = _('Enter a valid value.')
+    code = 'invalid'
+    url_validator = URLValidator()
+    path_validator = RegexValidator(r'(^/[/\S]+)$')
+    
+    def __call__(self, value):
+        passed = False
+        for validator in [self.path_validator, self.url_validator]:
+            try: 
+                validator(value)
+            except:
+                pass
+            else:
+                passed |= True
+                break
+        if not passed:
+            raise ValidationError(self.message, code=self.code)
 
 class FormManager(models.Manager):
     """
@@ -81,6 +101,15 @@ class AbstractForm(models.Model):
         max_length=200)
     email_subject = models.CharField(_("Subject"), max_length=200, blank=True)
     email_message = models.TextField(_("Message"), blank=True)
+    
+    redirect_url = models.CharField(_("Redirect url"), 
+                max_length=200, null=True, blank=True, validators=[RedirectUrlValidator()], 
+                help_text=_(' '.join(["Special for CMS integration ONLY.",
+                    "The url redirect to after a form successful submission.", 
+                    "Usually a URL starts with 'http:// or https://' for other domain",
+                    "or a plain path starting with '/' counting from the first file path within the same domain of this form",
+                    "<br/>e.g.: a form shows at 'http://example.com/a/b' and Redirect url defines '/c/d',",
+                    "redirection will result in http://example.com/c/d"])))
 
     objects = FormManager()
 

--- a/forms_builder/forms/tests.py
+++ b/forms_builder/forms/tests.py
@@ -4,15 +4,16 @@ from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.contrib.sites.models import Site
 from django.db import IntegrityError
+from django.http.response import HttpResponseRedirectBase
 from django.template import Context, RequestContext, Template
 from django.test import TestCase
 
+from forms_builder.forms.fields import NAMES, FILE
+from forms_builder.forms.forms import FormForForm
 from forms_builder.forms.models import (Form, Field,
                                         STATUS_DRAFT, STATUS_PUBLISHED)
-from forms_builder.forms.fields import NAMES, FILE
 from forms_builder.forms.settings import USE_SITES
 from forms_builder.forms.signals import form_invalid, form_valid
-from forms_builder.forms.forms import FormForForm
 
 
 class Tests(TestCase):
@@ -142,3 +143,18 @@ class Tests(TestCase):
                            required=True, visible=True)
         response = self.client.post(form.get_absolute_url(), {"foo": "bar"})
         self.assertTrue("This field is required" in str(response.content))
+
+    def test_form_redirect(self):
+        redirect_url='http://example.com/foo'
+        form = Form.objects.create(title='Test', redirect_url=redirect_url)
+        if USE_SITES:
+            form.sites.add(self._site)
+            form.save()
+        form.fields.create(label='field', field_type=NAMES[3][0], #Number
+                           required=True, visible=True)
+        form_absolute_url = form.get_absolute_url()
+        response = self.client.post(form_absolute_url, {'field': '0'})
+        self.assertEqual(response.url, redirect_url)
+        response = self.client.post(form_absolute_url, {'field': 'bar'})
+        self.assertFalse(isinstance(response , HttpResponseRedirectBase),
+                         'a validation failure should not trigger a redirection to display validation message')

--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -4,8 +4,6 @@ import json
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.sites.models import Site
-from django.core.mail import EmailMessage
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render_to_response
@@ -16,7 +14,7 @@ from email_extras.utils import send_mail_template
 
 from forms_builder.forms.forms import FormForForm
 from forms_builder.forms.models import Form
-from forms_builder.forms.settings import USE_SITES, EMAIL_FAIL_SILENTLY
+from forms_builder.forms.settings import EMAIL_FAIL_SILENTLY
 from forms_builder.forms.signals import form_invalid, form_valid
 from forms_builder.forms.utils import split_choices
 
@@ -59,7 +57,11 @@ class FormDetail(TemplateView):
             form_valid.send(sender=request, form=form_for_form, entry=entry)
             self.send_emails(request, form_for_form, form, entry, attachments)
             if not self.request.is_ajax():
-                return redirect("form_sent", slug=form.slug)
+                if form.redirect_url:
+                    successful_redirect = form.redirect_url
+                else:
+                    successful_redirect = reverse("form_sent", kwargs={"slug": form.slug})
+                return redirect(successful_redirect)
         context = {"form": form, "form_for_form": form_for_form}
         return self.render_to_response(context)
 


### PR DESCRIPTION
It would be great if we can show up a confirmation page with customized message after a successful submission.
Please refer to https://www.boxvoyageworkbench.com/en/contact-us/ or https://www.boxvoyageworkbench.com/en/products/schedule-reliability-application/download/

after successful submission page will go to https://www.boxvoyageworkbench.com/en/contact-us/confirmation/, 
https://www.boxvoyageworkbench.com/en/products/schedule-reliability-application/download-confirmation/

They are all defined in a newly added field in `forms_builder.forms.model.AbstractForm` called `redirect_url`.

People would need to run below command for this feature adoption if they have had  `forms_builder.forms` in their `INSTALLED_APPS` before

``` python
python manage.py migrate forms_builder.forms 0007
```
