### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ try:
             "sphinx-me >= 0.1.2",
             "unidecode",
             "django-email-extras >= 0.2",
-            "django >= 1.4, < 1.7",
+            "django >=  1.7",
             "future == 0.9.0",
         ],
         classifiers = [


### PR DESCRIPTION
Using linux mint.
Tried installing both from pip and from setup.py.
It automatically changed my django version to 1.6.7 both times.
When trying to run django forms builder with 1.6.7 it does not work, it needs django 1.7
