### PR TITLE
Fix for deprecated argument name (mimetype) to HttpResponse object which...

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -142,7 +142,7 @@ class FormAdmin(admin.ModelAdmin):
                 response.write(data)
                 return response
             elif XLWT_INSTALLED and export_xls:
-                response = HttpResponse(mimetype="application/vnd.ms-excel")
+                response = HttpResponse(content_type="application/vnd.ms-excel")
                 fname = "%s-%s.xls" % (form.slug, slugify(now().ctime()))
                 attachment = "attachment; filename=%s" % fname
                 response["Content-Disposition"] = attachment
@@ -192,7 +192,7 @@ class FormAdmin(admin.ModelAdmin):
         model = self.fieldentry_model
         field_entry = get_object_or_404(model, id=field_entry_id)
         path = join(fs.location, field_entry.value)
-        response = HttpResponse(mimetype=guess_type(path)[0])
+        response = HttpResponse(content_type=guess_type(path)[0])
         f = open(path, "r+b")
         response["Content-Disposition"] = "attachment; filename=%s" % f.name
         response.write(f.read())

--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -121,7 +121,7 @@ class FormAdmin(admin.ModelAdmin):
         export_xls = export_xls or request.POST.get("export_xls")
         if submitted:
             if export:
-                response = HttpResponse(mimetype="text/csv")
+                response = HttpResponse(content_type="text/csv")
                 fname = "%s-%s.csv" % (form.slug, slugify(now().ctime()))
                 attachment = "attachment; filename=%s" % fname
                 response["Content-Disposition"] = attachment


### PR DESCRIPTION
... was removed in django 1.7

CSV export was broken:

Internal Server Error: /admin/forms/form/5/entries/show/
Traceback (most recent call last):
  File "/home/mjoakes/webapps/caatas_2015a/lib/python2.7/Django-1.7.3-py2.7.egg/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/mjoakes/webapps/caatas_2015a/lib/python2.7/Django-1.7.3-py2.7.egg/django/utils/decorators.py", line 105, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/home/mjoakes/webapps/caatas_2015a/lib/python2.7/Django-1.7.3-py2.7.egg/django/views/decorators/cache.py", line 52, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/home/mjoakes/webapps/caatas_2015a/lib/python2.7/Django-1.7.3-py2.7.egg/django/contrib/admin/sites.py", line 206, in inner
    return view(request, *args, **kwargs)
  File "/home/mjoakes/lib/python2.7/forms_builder/forms/admin.py", line 124, in entries_view
    response = HttpResponse(mimetype="text/csv")
  File "/home/mjoakes/webapps/caatas_2015a/lib/python2.7/Django-1.7.3-py2.7.egg/django/http/response.py", line 318, in __init__
    super(HttpResponse, self).__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'mimetype'
