### PR TITLE
Remove Django depency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ try:
             "sphinx-me >= 0.1.2",
             "unidecode",
             "django-email-extras >= 0.2",
-            "django >= 1.4, < 1.8",
             "future == 0.9.0",
         ],
         classifiers = [


### PR DESCRIPTION
Hi,

This is an app, not a project, so I think your setup.py should not have a depency with any version of Django.

The problem, if you write "django >= 1.4, < 1.8" is that this app will overwrite the version of Django installed by the project which uses it (if installed at the end). If installed first, it will install an unwanted version of Django which will be overwritten soon after.
 
So, in my opinion, Django should be removed from the dependencies.