### PR TITLE
Don't require an old version of `future` that might conflict with oth…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ try:
             "unidecode",
             "django-email-extras >= 0.2",
             "django >= 1.6.10, < 1.8",
-            "future == 0.9.0",
+            "future >= 0.9",
         ],
         classifiers = [
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
…er installed package requirements.