### PR TITLE
Fix invalid worksheet name

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -148,7 +148,7 @@ class FormAdmin(admin.ModelAdmin):
                 response["Content-Disposition"] = attachment
                 queue = BytesIO()
                 workbook = xlwt.Workbook(encoding='utf8')
-                sheet = workbook.add_sheet(form.title[:31])
+                sheet = workbook.add_sheet(slugify(form.title[:31]))
                 for c, col in enumerate(entries_form.columns()):
                     sheet.write(0, c, col)
                 for r, row in enumerate(entries_form.rows(csv=True)):

--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -63,7 +63,7 @@ class FormDetail(TemplateView):
         return self.render_to_response(context)
 
     def render_to_response(self, context, **kwargs):
-        if self.request.is_ajax():
+        if self.request.is_ajax() and getattr(settings, 'FORM_BUILDER_AJAX_RESPONSE_TYPE', 'json') == 'json':
             json_context = json.dumps({
                 "errors": context["form_for_form"].errors,
                 "form": context["form_for_form"].as_p(),


### PR DESCRIPTION
An exception is raised when trying to export a form which has non alphanumeric characters in it's title. Slugifying the title before using it as a worksheet name fixes this problem.