### PR TITLE
Simple updates for Django 1.9

### DIFF
--- a/forms_builder/forms/admin.py
+++ b/forms_builder/forms/admin.py
@@ -84,7 +84,7 @@ class FormAdmin(admin.ModelAdmin):
         Add the entries view to urls.
         """
         urls = super(FormAdmin, self).get_urls()
-        extra_urls = patterns("",
+        extra_urls = [
             url("^(?P<form_id>\d+)/entries/$",
                 self.admin_site.admin_view(self.entries_view),
                 name="form_entries"),
@@ -97,7 +97,7 @@ class FormAdmin(admin.ModelAdmin):
             url("^file/(?P<field_entry_id>\d+)/$",
                 self.admin_site.admin_view(self.file_view),
                 name="form_file"),
-        )
+        ]
         return extra_urls + urls
 
     def entries_view(self, request, form_id, show=False, export=False,

--- a/forms_builder/forms/urls.py
+++ b/forms_builder/forms/urls.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import patterns, url
+from .views import form_sent, form_detail
 
-
-urlpatterns = patterns("forms_builder.forms.views",
-    url(r"(?P<slug>.*)/sent/$", "form_sent", name="form_sent"),
-    url(r"(?P<slug>.*)/$", "form_detail", name="form_detail"),
-)
+urlpatterns = [
+    url(r"(?P<slug>.*)/sent/$", form_sent, name="form_sent"),
+    url(r"(?P<slug>.*)/$", form_detail, name="form_detail"),
+]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ try:
             "sphinx-me >= 0.1.2",
             "unidecode",
             "django-email-extras >= 0.2",
-            "django >= 1.6.10, < 1.8",
+            "django >= 1.6.10",
             "future <= 0.15.0",
         ],
         classifiers = [


### PR DESCRIPTION
These are simple changes that were needed to get the app to install and run in a site under 1.9.

The upstream version actually runs fine with only the change to setup.py.  It does emit warnings about the url() and patterns() calls because the API there changed and the deprecated changes go away in 1.10.

Since the changes to urlpatterns might break things under 1.7, I need some help testing this patch under Django 1.7.  I also need some volunteer testers that can report things that break in 1.9.