### PR TITLE
replaced ``isinstance`` with ``issubclass``

### DIFF
--- a/forms_builder/forms/templatetags/forms_builder_tags.py
+++ b/forms_builder/forms/templatetags/forms_builder_tags.py
@@ -5,7 +5,7 @@ from django import template
 from django.template.loader import get_template
 
 from forms_builder.forms.forms import FormForForm
-from forms_builder.forms.models import Form
+from forms_builder.forms.models import AbstractForm
 
 
 register = template.Library()
@@ -30,7 +30,7 @@ class BuiltFormNode(template.Node):
                 form = None
         else:
             form = template.Variable(self.value).resolve(context)
-        if not isinstance(form, Form) or not form.published(for_user=user):
+        if not issubclass(form.__class__, AbstractForm) or not form.published(for_user=user):
             return ""
         t = get_template("forms/includes/built_form.html")
         context["form"] = form


### PR DESCRIPTION
make it possible to use ``forms_builder`` template tags with derived models