### PR TITLE
Add FileStorage abstraction for handling remote file storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,10 +126,11 @@ in the CSV export. By default these uploaded files are stored in an
 obscured location under your project's ``MEDIA_ROOT`` directory but
 ideally the should be stored somewhere inaccessible to the public. To
 set the location where files are stored to be somewhere outside of your
-project's ``MEDIA_ROOT`` directory you just need to define the
+project's ``MEDIA_ROOT`` directory you just need to define the either the
 ``FORMS_BUILDER_UPLOAD_ROOT`` setting in your project's ``settings``
-module. Its value should be an absolute path on the web server that
-isn't accessible to the public.
+module or the ``FORMS_BUILDER_FILE_STORAGE`` setting. The
+``FORMS_BUILDER_UPLOAD_ROOT`` value should be an absolute path on the web
+server that isn't accessible to the public.
 
 
 Configuration
@@ -146,6 +147,9 @@ module.
   will be added to the form field types. Defaults to ``()``
 * ``FORMS_BUILDER_UPLOAD_ROOT`` - The absolute path where files will
   be uploaded to. Defaults to ``None``
+* ``FORMS_BUILDER_FILE_STORAGE`` - The class path of the Django storage class
+  to use for storing files. Defaults to ``None`` which uses the default file
+  storage.
 * ``FORMS_BUILDER_USE_HTML5`` - Boolean controlling whether HTML5 form
   fields are used. Defaults to ``True``
 * ``FORMS_BUILDER_USE_SITES`` - Boolean controlling whether forms are

--- a/forms_builder/forms/forms.py
+++ b/forms_builder/forms/forms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from future.builtins import int, range, str
 
@@ -8,7 +9,6 @@ from uuid import uuid4
 import django
 from django import forms
 from django.forms.extras import SelectDateWidget
-from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.template import Template
 from django.utils.safestring import mark_safe
@@ -20,9 +20,10 @@ from forms_builder.forms import settings
 from forms_builder.forms.utils import now, split_choices
 
 
-fs = default_storage
 if settings.UPLOAD_ROOT is not None:
-    fs = default_storage.__class__(location=settings.UPLOAD_ROOT)
+    fs = settings.FILE_STORAGE(location=settings.UPLOAD_ROOT)
+else:
+    fs = settings.FILE_STORAGE()
 
 
 ##############################

--- a/forms_builder/forms/settings.py
+++ b/forms_builder/forms/settings.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-
+from django.core.files.storage import get_storage_class
 
 if not ("django.contrib.sites" in settings.INSTALLED_APPS):
     raise ImproperlyConfigured("django.contrib.sites is required")
@@ -22,6 +23,9 @@ EXTRA_WIDGETS = getattr(settings, "FORMS_BUILDER_EXTRA_WIDGETS", ())
 
 # The absolute path where files will be uploaded to.
 UPLOAD_ROOT = getattr(settings, "FORMS_BUILDER_UPLOAD_ROOT", None)
+
+# The File Storage class to use, uses default file storage if None
+FILE_STORAGE = get_storage_class(getattr(settings, "FORMS_BUILDER_FILE_STORAGE", None))
 
 # Boolean controlling whether HTML5 form fields are used.
 USE_HTML5 = getattr(settings, "FORMS_BUILDER_USE_HTML5", True)


### PR DESCRIPTION
Instead of using Python's `open()` and assuming that the files are stored locally, use the file storage abstraction to open the file.

This also allows the specification of a separate file storage class.