### PR TITLE
Context as a dict for render in BuiltFormNode. Required by Django 1.11.

### DIFF
--- a/forms_builder/forms/templatetags/forms_builder_tags.py
+++ b/forms_builder/forms/templatetags/forms_builder_tags.py
@@ -37,7 +37,7 @@ class BuiltFormNode(template.Node):
         context["form"] = form
         form_args = (form, context, post or None, files or None)
         context["form_for_form"] = FormForForm(*form_args)
-        return t.render(context)
+        return t.render(context.flatten())
 
 
 @register.tag


### PR DESCRIPTION
Django 1.11 accepts dict instead of instance Context.