### PR TITLE
Add Django 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.8.x.zip
-  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.9.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.10.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.11.x.zip
 python:
   - "2.7"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ try:
             "sphinx-me >= 0.1.2",
             "unidecode",
             "django-email-extras >= 0.2",
-            "django >= 1.8, < 1.11",
+            "django >= 1.8, < 2.0",
             "future <= 0.15.0",
         ],
         classifiers = [


### PR DESCRIPTION
This PR moves the Django pin in setup.py from `<1.11` to `<2.0`. It also removes Django 1.9 from the Travis test matrix (since 1.9 has long been EOL) and adds Django 1.11 in its place.