### PR TITLE
Changing multiple checkboxes from "must check all" to "check at least one"

### DIFF
--- a/forms_builder/forms/forms.py
+++ b/forms_builder/forms/forms.py
@@ -202,7 +202,10 @@ class FormForForm(forms.ModelForm):
 
             # Add identifying CSS classes to the field.
             css_class = field_class.__name__.lower()
-            if field.required:
+            # Do not add the 'required' field to the CheckboxSelectMultiple because it will 
+            # mean that all checkboxes have to be checked instead of the usual use case of
+            # "at least one".  
+            if field.required and (field_widget != forms.CheckboxSelectMultiple):
                 css_class += " required"
                 if settings.USE_HTML5:
                     # Except Django version 1.10 this is necessary for all versions from 1.8 to 1.11.


### PR DESCRIPTION
When using multiple checkboxes with the field marked as "required" don't pass the "required" attribute through to the widget as it means that all the checkboxes will need to be checked to validate.

I'd say that it's rarely the case you're really expecting the user to check every one; more that you expect them to check one or more.  I think you'd have to distinguish these two use cases in the drop-down menu for the field type, but in the meantime, I propose that the default be the "at least one" scenario.  The side effect of this that it can't be enforced in the client-side HTML5 without using Javascript.