### PR TITLE
Change field type choices to point at settings rather than hard code

### DIFF
--- a/forms_builder/forms/migrations/0001_initial.py
+++ b/forms_builder/forms/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 
-from forms_builder.forms import settings
+from forms_builder.forms import fields, settings
 
 
 class Migration(migrations.Migration):
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('label', models.CharField(max_length=200, verbose_name='Label')),
                 ('slug', models.SlugField(default='', max_length=100, verbose_name='Slug', blank=True)),
-                ('field_type', models.IntegerField(verbose_name='Type', choices=[(1, 'Single line text'), (2, 'Multi line text'), (3, 'Email'), (13, 'Number'), (14, 'URL'), (4, 'Check box'), (5, 'Check boxes'), (6, 'Drop down'), (7, 'Multi select'), (8, 'Radio buttons'), (9, 'File upload'), (10, 'Date'), (11, 'Date/time'), (15, 'Date of birth'), (12, 'Hidden')])),
+                ('field_type', models.IntegerField(verbose_name='Type', choices=fields.NAMES)),
                 ('required', models.BooleanField(default=True, verbose_name='Required')),
                 ('visible', models.BooleanField(default=True, verbose_name='Visible')),
                 ('choices', models.CharField(help_text='Comma separated options where applicable. If an option itself contains commas, surround the option starting with the `character and ending with the ` character.', max_length=1000, verbose_name='Choices', blank=True)),


### PR DESCRIPTION
As discussed in issue #220, there is a problem when a user adds extra fields in the settings. Because the choices are hard coded, whenever a new choice is added, Django wants to create a new migration.

To solve this problem the migration needs to point to the settings choices rather than have them hard coded, as discussed in [this thread](https://code.djangoproject.com/ticket/23581).

This pull request resolves this issue.