### PR TITLE
Fixing the side effects in Django < 1.10

### DIFF
--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -36,7 +36,9 @@ class FormDetail(TemplateView):
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
         login_required = context["form"].login_required
-        if login_required and not request.user.is_authenticated:
+        user_auth_property = request.user.is_authenticated
+        is_user_authenticated = user_auth_property() if callable(user_auth_property) else user_auth_property
+        if login_required and not is_user_authenticated:
             path = urlquote(request.get_full_path())
             bits = (settings.LOGIN_URL, REDIRECT_FIELD_NAME, path)
             return redirect("%s?%s=%s" % bits)


### PR DESCRIPTION
As request.user.is_authenticated was no longer a method it was changed to use as boolean.
But this has a side effect for Django < 1.10 where it is a method. Hence added 'is_user_authenticated' which works conditionally and fixes the side effect.