### PR TITLE
Fix for Issue #225. error in 'render_to_response'

### DIFF
--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -120,4 +120,9 @@ def form_sent(request, slug, template="forms/form_sent.html"):
     """
     published = Form.objects.published(for_user=request.user)
     context = {"form": get_object_or_404(published, slug=slug)}
-    return render_to_response(template, context, RequestContext(request))
+    response = None
+    try:
+        resposne = render_to_response(template, context, RequestContext(request))
+    except KeyError:
+        response = render(request, template, context)
+    return response


### PR DESCRIPTION
Keyerror 'request' in context was fixed. Used render_to_response and also render methods to generate response, which can work for almost all features of Django.