### PR TITLE
Ensure the length of the validated slug does not exceed the maximum field length

### DIFF
--- a/forms_builder/forms/tests.py
+++ b/forms_builder/forms/tests.py
@@ -126,6 +126,14 @@ class Tests(TestCase):
         except IntegrityError:
             self.fail("Slugs were not auto-unique")
 
+    def test_field_validate_slug_length(self):
+        max_slug_length = 2000
+        form = Form.objects.create(title="Test")
+        field = Field(form=form,
+                      label='x' * (max_slug_length + 1), field_type=NAMES[0][0])
+        field.save()
+        self.assertLessEqual(len(field.slug), max_slug_length)
+
     def test_field_default_ordering(self):
         form = Form.objects.create(title="Test")
         form.fields.create(label="second field",

--- a/forms_builder/forms/utils.py
+++ b/forms_builder/forms/utils.py
@@ -27,12 +27,16 @@ def unique_slug(manager, slug_field, slug):
     Ensure slug is unique for the given manager, appending a digit
     if it isn't.
     """
+    max_length = manager.model._meta.get_field(slug_field).max_length
+    slug = slug[:max_length]
     i = 0
     while True:
         if i > 0:
             if i > 1:
                 slug = slug.rsplit("-", 1)[0]
-            slug = "%s-%s" % (slug, i)
+            # We need to keep the slug length under the slug fields max length. We need to
+            # account for the length that is added by adding a random integer and `-`.
+            slug = "%s-%s" % (slug[:max_length - len(str(i)) - 1], i)
         if not manager.filter(**{slug_field: slug}):
             break
         i += 1


### PR DESCRIPTION
As we are appending data to the end of a slug it adds additional length
to the slug. This can mean we have gone past the fields length causing
database errors.

As we are passing a manager and the field name into the function we can
determine the maximum length of the field and limit the slug to that
length.