### PR TITLE
Set slug max_length equal to label max_length

### DIFF
--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -171,7 +171,7 @@ class AbstractField(models.Model):
     """
 
     label = models.CharField(_("Label"), max_length=settings.LABEL_MAX_LENGTH)
-    slug = models.SlugField(_('Slug'), max_length=2000, blank=True,
+    slug = models.SlugField(_('Slug'), max_length=settings.LABEL_MAX_LENGTH, blank=True,
             default="")
     field_type = models.IntegerField(_("Type"), choices=fields.NAMES)
     required = models.BooleanField(_("Required"), default=True)


### PR DESCRIPTION
Since slug is formed based on label it makes sense for slug max_length to be taken from the same source as label's max_length, namely `settings.LABEL_MAX_LENGTH`