### PR TITLE
Added 'django.contrib.sites' as required apps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Add ``forms_builder.forms`` to ``INSTALLED_APPS`` in your project's
 
     INSTALLED_APPS = (
         # other apps
+        'django.contrib.sites',  # ensure this is present
         'forms_builder.forms',
     )
 


### PR DESCRIPTION
Installation does not work when 'django.contrib.sites' is not already included