### PR TITLE
Fix of admin_links for Django 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.11.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/2.0.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/2.1.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/2.2.x.zip
 python:
   - "2.7"
   - "3.4"
@@ -17,8 +18,12 @@ matrix:
       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/2.0.x.zip
     - python: "2.7"
       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/2.1.x.zip
+    - python: "2.7"
+      env: DJANGO_VERSION=https://github.com/django/django/archive/stable/2.2.x.zip
     - python: "3.4"
       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/2.1.x.zip
+    - python: "3.4"
+      env: DJANGO_VERSION=https://github.com/django/django/archive/stable/2.2.x.zip
 install:
   - pip install $DJANGO_VERSION
   - pip install .

--- a/forms_builder/example_project/settings.py
+++ b/forms_builder/example_project/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'django.contrib.messages',
     'forms_builder.forms',
 )
 

--- a/forms_builder/forms/models.py
+++ b/forms_builder/forms/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django import VERSION as DJANGO_VERSION
 from django.contrib.sites.models import Site
+from django.utils.html import format_html_join
 
 try:
     from django.urls import reverse
@@ -142,16 +143,13 @@ class AbstractForm(models.Model):
         return reverse("form_detail", kwargs={"slug": self.slug})
 
     def admin_links(self):
-        kw = {"args": (self.id,)}
-        links = [
+        kw = {"args": (self.id, )}
+        return format_html_join("\n", "<div><a href='{1}'>{0}</a></div>", (
             (_("View form on site"), self.get_absolute_url()),
             (_("Filter entries"), reverse("admin:form_entries", **kw)),
             (_("View all entries"), reverse("admin:form_entries_show", **kw)),
             (_("Export all entries"), reverse("admin:form_entries_export", **kw)),
-        ]
-        for i, (text, url) in enumerate(links):
-            links[i] = "<a href='%s'>%s</a>" % (url, ugettext(text))
-        return "<br>".join(links)
+        ))
     admin_links.allow_tags = True
     admin_links.short_description = ""
 

--- a/forms_builder/forms/tests.py
+++ b/forms_builder/forms/tests.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.utils.safestring import SafeText
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.contrib.sites.models import Site
@@ -239,3 +240,14 @@ class Tests(TestCase):
                 <option value="two" selected>two</option>
                 <option value="three">three</option>
             </select>""", html=True)
+
+    def test_admin_link(self):
+        form = Form.objects.create(title="Test")
+        content = form.admin_links()
+        self.assertIsInstance(content, SafeText)
+        self.assertInHTML(content, """
+            <div><a href='/forms/test/'>View form on site</a></div>
+            <div><a href='/admin/forms/form/1/entries/'>Filter entries</a></div>
+            <div><a href='/admin/forms/form/1/entries/show/'>View all entries</a></div>
+            <div><a href='/admin/forms/form/1/entries/export/'>Export all entries</a></div>
+        """)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ try:
             "sphinx-me >= 0.1.2",
             "unidecode",
             "django-email-extras >= 0.2",
-            "django >= 1.8, < 2.2",
+            "django >= 1.11, < 2.2.99",
             "future <= 0.15.0",
         ],
         classifiers = [


### PR DESCRIPTION
Hi, here I offer some fixies for Django 2. The most serious is fix of function `admin_links`:

 * Html code from function `admin_links` must be marked as `SafeText`.
   * Replace `<br>` to container `<div>`. Tag BR is unpaired tag. It is better to use a container, for examle for css styling.
* `'django.contrib.messages'`, in `INSTALL_APP` is required by Django 2.2.
* I suggest to restrict Django versions to `django >= 1.11, < 2.2.99`.